### PR TITLE
Bug fix with model relations

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -340,7 +340,7 @@ class ModelsCommand extends Command
                         $search = '$this->' . $relation . '(';
                         if ($pos = stripos($code, $search)) {
                             $code = substr($code, $pos + strlen($search));
-                            $arguments = explode(',', substr($code, 0, strpos($code, ');')));
+                            $arguments = explode(',', substr($code, 0, strpos($code, ')')));
                             //Remove quotes, ensure 1 \ in front of the model
                             $returnModel = $this->getClassName($arguments[0], $model);
                             if ($relation === "belongsToMany" or $relation === 'hasMany' or $relation === 'morphMany' or $relation === 'morphToMany') {


### PR DESCRIPTION
If relation has other methods, generating doc is fail.
E.g.

``` php
$this->belongsToMany('App\User')->withTimestamps();
```

generate this:

```
@property-read \Illuminate\Database\Eloquent\Collection|\App\User')->withTimestamps([] $users 
```
